### PR TITLE
feat: enable real-time transcript rendering

### DIFF
--- a/examples/manual_cli.py
+++ b/examples/manual_cli.py
@@ -30,6 +30,8 @@ async def main():
         api_key=os.environ.get("OPENAI_API_KEY"),
         on_text_delta=lambda text: print(f"\nAssistant: {text}", end="", flush=True),
         on_audio_delta=lambda audio: audio_handler.play_audio(audio),
+        on_input_transcript=lambda transcript: print(f"\nYou said: {transcript}\nAssistant: ", end="", flush=True),
+        on_output_transcript=lambda transcript: print(f"{transcript}", end="", flush=True),
         tools=tools,
     )
     


### PR DESCRIPTION
This PR adds three event message handlers to realtime-client.py to handle incoming transcript-related messages efficiently:
1. conversation.item.input_audio_transcription.completed
2. response.audio_transcript.delta
3. response.audio_transcript.done

the transcript will be printed as the audio plays in real-time by running the display function in a separate thread to ensure non-blocking I/O.
