### PR TITLE
Transcribe initial server response

### DIFF
--- a/openai_realtime_client/client/realtime_client.py
+++ b/openai_realtime_client/client/realtime_client.py
@@ -225,6 +225,9 @@ class RealtimeClient:
         if functions:
             event["response"]["tools"] = functions
             
+        # Make sure we print the transcript for the response
+        self._print_input_transcript = True
+
         await self.ws.send(json.dumps(event))
 
     async def send_function_result(self, call_id: str, result: Any) -> None:


### PR DESCRIPTION
I'm not sure I fully understand the purpose of `_print_input_transcript`, but by setting it to `False` initially, you prevent the transcription of a server response when triggered by `create_response()`. I'm using this because I want the server to initial the conversation.